### PR TITLE
added field for optional shape_id in Trip structs

### DIFF
--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -222,6 +222,7 @@ fn create_trips(
         service_id: rt.service_id,
         route_id: rt.route_id,
         stop_times: vec![],
+        shape_id: rt.shape_id,
     }));
     for s in raw_stop_times {
         let trip = &mut trips

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -387,6 +387,7 @@ pub struct RawTrip {
     pub id: String,
     pub service_id: String,
     pub route_id: String,
+    pub shape_id: Option<String>,
 }
 
 impl Type for RawTrip {
@@ -417,6 +418,7 @@ pub struct Trip {
     pub service_id: String,
     pub route_id: String,
     pub stop_times: Vec<StopTime>,
+    pub shape_id: Option<String>,
 }
 
 impl Type for Trip {


### PR DESCRIPTION
In the GTFS specification, `trips` have an optional `shape_id` field.
To reflect this in the data structures, I added a field to the `Trip` and `RawTrip` structs using Rust's `Option` type.